### PR TITLE
Disable visit note smoke tests

### DIFF
--- a/src/test/java/org/openmrs/module/mirebalais/smoke/suite/HaitiSmokeTestSuite.java
+++ b/src/test/java/org/openmrs/module/mirebalais/smoke/suite/HaitiSmokeTestSuite.java
@@ -16,8 +16,8 @@ import org.openqa.selenium.WebDriver;
 @Suite.SuiteClasses({
         CaptureVitalsTest.class,
         CheckInTest.class,
-        PatientRegistrationHaitiFlowTest.class,
-        VisitNoteTest.class
+        PatientRegistrationHaitiFlowTest.class
+//        VisitNoteTest.class  -- all tests intermittently failing
                     })
 public class HaitiSmokeTestSuite {
 


### PR DESCRIPTION
Right now, the visit note tests fail intermittently, causing a lot of noise in our inboxes. Even if one day one of these tests failed because of an actual outage, it would still be unhelpful, because we would almost certainly not have investigated the failure. Smoke tests should indicate that something is on fire.