### PR TITLE
Disable change password test which never actually worked

### DIFF
--- a/src/test/java/org/openmrs/module/mirebalais/smoke/UserAdminTest.java
+++ b/src/test/java/org/openmrs/module/mirebalais/smoke/UserAdminTest.java
@@ -2,6 +2,7 @@ package org.openmrs.module.mirebalais.smoke;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.openmrs.module.mirebalais.apploader.CustomAppLoaderConstants;
 import org.openmrs.module.mirebalais.smoke.helper.NameGenerator;
@@ -43,6 +44,9 @@ public class UserAdminTest extends DbTest {
 	}
 	
 	@Test
+	@Ignore
+	// OpenMRS does not support deleting a user that has changed their password due to FOREIGN KEY self-reference
+	// See https://issues.openmrs.org/browse/TRUNK-5736
 	public void createUserWithPhysicianRoleAndUserChangesOwnPassword() throws Exception {
 
         userAdmin.createPhysicianAccount(NameGenerator.getUserFirstName(), NameGenerator.getUserLastName(), username,

--- a/src/test/java/org/openmrs/module/mirebalais/smoke/UserAdminTest.java
+++ b/src/test/java/org/openmrs/module/mirebalais/smoke/UserAdminTest.java
@@ -51,8 +51,9 @@ public class UserAdminTest extends DbTest {
 		
 		appDashboard.openMyAccountApp();
 		myAccountApp.openChangePassword();
-		myAccountApp.changePassword(DEFAULT_PASSWORD, DEFAULT_PASSWORD);
-		logOutAndLogInWithNewUser(username);
+		String newPassword = "something else!";
+		myAccountApp.changePassword(DEFAULT_PASSWORD, newPassword);
+		logOutAndLogInWithNewUser(username, newPassword);
 		
 		assertThat(appDashboard.isActiveVisitsAppPresented(), is(true));
 
@@ -155,11 +156,15 @@ public class UserAdminTest extends DbTest {
 	private String createUser() {
 		return new String("user" + System.currentTimeMillis());
 	}
-	
+
 	private void logOutAndLogInWithNewUser(String username) throws InterruptedException {
+		logOutAndLogInWithNewUser(username, DEFAULT_PASSWORD);
+	}
+
+	private void logOutAndLogInWithNewUser(String username, String password) throws InterruptedException {
 		Thread.sleep(5000);
         header.logOut();
-		loginPage.logIn(username, DEFAULT_PASSWORD);
+		loginPage.logIn(username, password);
 	}
 	
 }


### PR DESCRIPTION
The change password test would only pass because the Selenium "click" on the Submit button never actually worked, and the test was having the user change their password to itself. So this test was testing that nothing was happening, and indeed, nothing was happening.

Once the clicks were fixed, it started causing the cleanup to fail because of [TRUNK-5736 Cannot delete user who has changed their password](https://issues.openmrs.org/browse/TRUNK-5736).

I didn't figure out how to mitigate the problem, so I've disabled the test for now.