### PR TITLE
Click on first

### DIFF
--- a/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/VisitNote.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/VisitNote.java
@@ -14,6 +14,13 @@
 
 package org.openmrs.module.mirebalais.smoke.pageobjects;
 
+import static org.openqa.selenium.support.ui.ExpectedConditions.invisibilityOfElementLocated;
+import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
+import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
+
+import java.util.HashMap;
+import java.util.List;
+
 import org.openmrs.module.mirebalais.apploader.CustomAppLoaderConstants;
 import org.openmrs.module.mirebalais.smoke.pageobjects.forms.AdmissionNoteForm;
 import org.openmrs.module.mirebalais.smoke.pageobjects.forms.ChiefComplaintForm;
@@ -36,15 +43,6 @@ import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
-import org.openqa.selenium.support.ui.ExpectedConditions;
-
-import java.util.HashMap;
-import java.util.List;
-
-import static org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable;
-import static org.openqa.selenium.support.ui.ExpectedConditions.invisibilityOfElementLocated;
-import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated;
-import static org.openqa.selenium.support.ui.ExpectedConditions.visibilityOfElementLocated;
 
 public class VisitNote extends AbstractPageObject {
 	
@@ -157,12 +155,11 @@ public class VisitNote extends AbstractPageObject {
     public void expandFirstEncounter() {clickOn(expandEncounter);}
 
     public void editFirstEncounter() {
-	    wait15seconds.until(elementToBeClickable(editEncounter));
-        clickOn(editEncounter);
+	    clickOnFirst(editEncounter);
     }
 
 	public void deleteFirstEncounter() {
-		clickOn(deleteEncounter);
+		clickOnFirst(deleteEncounter);
 		clickOn(By.className("delete-encounter-button") );
 		wait5seconds.until(invisibilityOfElementLocated(By.className("delete-encounter-dialog")));
 	}


### PR DESCRIPTION
I have no idea what changed based on my commit, but I found that these tests were failing due to the fact that hidden elements with matching CSS selectors (classes) were present in the page prior to the element we were trying to select.  This change accounts for this, by implementing a clickFirst that will first find all of the clickable instances, and then click on the first of those that are found.