### PR TITLE
Set user locales

### DIFF
--- a/src/main/java/org/openmrs/module/mirebalais/smoke/GeneralLoginPage.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/GeneralLoginPage.java
@@ -11,6 +11,11 @@ public class GeneralLoginPage extends LoginPage {
     }
 
     @Override
+    public String getLocale() {
+        return "en";
+    }
+
+    @Override
     public void logIn(String user, String password, String location) {
         driver.findElement(By.id("username")).sendKeys(user);
         driver.findElement(By.id("password")).sendKeys(password);

--- a/src/main/java/org/openmrs/module/mirebalais/smoke/dataModel/User.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/dataModel/User.java
@@ -26,8 +26,11 @@ public class User {
 
     private String userUuid;
 
+    private String defaultLocale;
+
     public User(BigInteger personId, String uuid, BigInteger personNameId, BigInteger userId, String username, String role,
-                BigInteger providerId, String providerUuid, Integer providerRoleId, String personNameUuid, String userUuid) {
+                BigInteger providerId, String providerUuid, Integer providerRoleId, String personNameUuid, String userUuid,
+                String defaultLocale) {
         this.personId = personId;
         this.uuid = uuid;
         this.personNameId = personNameId;
@@ -39,6 +42,7 @@ public class User {
         this.providerRoleId = providerRoleId;
         this.personNameUuid = personNameUuid;
         this.userUuid = userUuid;
+        this.defaultLocale = defaultLocale;
     }
 
     public String getRole() {
@@ -92,6 +96,8 @@ public class User {
     public String getUser_uuid() {
         return userUuid;
     }
+
+    public String getDefaultLocale() { return defaultLocale; }
 
     @Override
     public String toString() {

--- a/src/main/java/org/openmrs/module/mirebalais/smoke/helper/SmokeTestProperties.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/helper/SmokeTestProperties.java
@@ -12,20 +12,20 @@ public class SmokeTestProperties {
 
     public String getWebAppUrl() {
         if (webAppUrl == null) {
-            webAppUrl = envOrDefault("WEBAPP_URL", "http://localhost:8080/openmrs");
+            webAppUrl = envOrDefault("WEBAPP_URL", "http://localhost:7080/openmrs");
         }
 
         return webAppUrl;
     }
 
     public String getDatabaseUrl() {
-        return envOrDefault("DATABASE_URL", "jdbc:mysql://localhost:3306/openmrs");
+        return envOrDefault("DATABASE_URL", "jdbc:mysql://localhost:3308/hum");
 
     }
 
     public String getDatabaseUsername() {
         if (databaseUsername == null) {
-            databaseUsername = envOrDefault("DATABASE_USERNAME", "openmrs");
+            databaseUsername = envOrDefault("DATABASE_USERNAME", "root");
         }
 
         return databaseUsername;
@@ -33,7 +33,7 @@ public class SmokeTestProperties {
 
     public String getDatabasePassword() {
         if (databasePassword == null) {
-            databasePassword = envOrDefault("DATABASE_PASSWORD", "openmrs");
+            databasePassword = envOrDefault("DATABASE_PASSWORD", "Admin123");
         }
 
         return databasePassword;

--- a/src/main/java/org/openmrs/module/mirebalais/smoke/helper/UserDatabaseHandler.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/helper/UserDatabaseHandler.java
@@ -30,20 +30,20 @@ public class UserDatabaseHandler extends BaseDatabaseHandler {
 
     protected static List<String> usernamesToDelete = new ArrayList<String>();
 	
-	public static User insertNewPhysicianUser() throws Exception {
+	public static User insertNewPhysicianUser(String locale) throws Exception {
 
-		return createUserWithApplicationAndProviderRole("physician", "Physician");
+		return createUserWithApplicationAndProviderRole("physician", "Physician", locale);
 	}
 	
-	public static User insertNewPharmacyManagerUser() throws Exception {
-		return createUserWithApplicationAndProviderRole("pharmacyManager", "Pharmacist");
+	public static User insertNewPharmacyManagerUser(String locale) throws Exception {
+		return createUserWithApplicationAndProviderRole("pharmacyManager", "Pharmacist", locale);
 	}
 
-    public static User insertNewArchivistUser() throws Exception {
-        return createUserWithApplicationAndProviderRole("archivistClerk", "Archivist/Clerk");
+    public static User insertNewArchivistUser(String locale) throws Exception {
+        return createUserWithApplicationAndProviderRole("archivistClerk", "Archivist/Clerk", locale);
     }
 	
-	private static User createUserWithApplicationAndProviderRole(String role, String providerRole) throws Exception {
+	private static User createUserWithApplicationAndProviderRole(String role, String providerRole, String locale) throws Exception {
 		User user;
 		
 		try {
@@ -54,7 +54,7 @@ public class UserDatabaseHandler extends BaseDatabaseHandler {
 			
 			user = new User(getNextAutoIncrementFor("person"), UUID.randomUUID().toString(),
 			        getNextAutoIncrementFor("person_name"), userId, username, role, getNextAutoIncrementFor("provider"),
-			        UUID.randomUUID().toString(), providerRoleId, UUID.randomUUID().toString(), UUID.randomUUID().toString());
+			        UUID.randomUUID().toString(), providerRoleId, UUID.randomUUID().toString(), UUID.randomUUID().toString(), locale);
 			
 			IDataSet dataset = createDataset(user);
 			datasets.put(user, dataset);

--- a/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/HSNLoginPage.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/HSNLoginPage.java
@@ -11,6 +11,11 @@ public class HSNLoginPage  extends LoginPage {
     }
 
     @Override
+    public String getLocale() {
+        return "ht";
+    }
+
+    @Override
     public void logIn(String user, String password, String location) {
         driver.findElement(By.id("username")).sendKeys(user);
         driver.findElement(By.id("password")).sendKeys(password);

--- a/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/LiberiaLoginPage.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/LiberiaLoginPage.java
@@ -11,6 +11,11 @@ public class LiberiaLoginPage extends LoginPage {
     }
 
     @Override
+    public String getLocale() {
+        return "en";
+    }
+
+    @Override
     public void logIn(String user, String password, String location) {
         driver.findElement(By.id("username")).sendKeys(user);
         driver.findElement(By.id("password")).sendKeys(password);

--- a/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/LoginPage.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/LoginPage.java
@@ -11,6 +11,8 @@ public abstract class LoginPage {
 
 	public abstract void logIn(String user, String password, String location);
 
+	public abstract String getLocale();
+
 	public void logIn(String user, String password) {
 		logIn(user, password, null);
 	}
@@ -24,22 +26,22 @@ public abstract class LoginPage {
     }
 
 	public void logInAsPhysicianUser() throws Exception {
-		User clinical = UserDatabaseHandler.insertNewPhysicianUser();
+		User clinical = UserDatabaseHandler.insertNewPhysicianUser(getLocale());
 		this.logIn(clinical.getUsername(), "Admin123");
 	}
 
     public void logInAsPhysicianUser(String location) throws Exception {
-        User clinical = UserDatabaseHandler.insertNewPhysicianUser();
+        User clinical = UserDatabaseHandler.insertNewPhysicianUser(getLocale());
         this.logIn(clinical.getUsername(), "Admin123", location);
     }
 
 	public void logInAsPharmacyManagerUser() throws Exception {
-		User pharmacist = UserDatabaseHandler.insertNewPharmacyManagerUser();
+		User pharmacist = UserDatabaseHandler.insertNewPharmacyManagerUser(getLocale());
 		this.logIn(pharmacist.getUsername(), "Admin123", "Klinik Ekstèn Famasi");
 	}
 
     public void logInAsArchivistUser() throws Exception{
-        User archivist = UserDatabaseHandler.insertNewArchivistUser();
+        User archivist = UserDatabaseHandler.insertNewArchivistUser(getLocale());
         this.logIn(archivist.getUsername(), "Admin123");
     }
 

--- a/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/MentalHealthLoginPage.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/MentalHealthLoginPage.java
@@ -11,6 +11,11 @@ public class MentalHealthLoginPage extends LoginPage {
     }
 
     @Override
+    public String getLocale() {
+        return "ht";
+    }
+
+    @Override
     public void logIn(String user, String password, String location) {
         driver.findElement(By.id("username")).sendKeys(user);
         driver.findElement(By.id("password")).sendKeys(password);

--- a/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/MexicoLoginPage.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/MexicoLoginPage.java
@@ -10,6 +10,11 @@ public class MexicoLoginPage extends LoginPage {
     }
 
     @Override
+    public String getLocale() {
+        return "es";
+    }
+
+    @Override
     public void logIn(String user, String password, String location) {
         driver.findElement(By.id("username")).sendKeys(user);
         driver.findElement(By.id("password")).sendKeys(password);

--- a/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/MirebalaisLoginPage.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/MirebalaisLoginPage.java
@@ -11,6 +11,11 @@ public class MirebalaisLoginPage extends LoginPage {
     }
 
     @Override
+    public String getLocale() {
+        return "ht";
+    }
+
+    @Override
     public void logIn(String user, String password, String location) {
         driver.findElement(By.id("username")).sendKeys(user);
         driver.findElement(By.id("password")).sendKeys(password);

--- a/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/PeruLoginPage.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/PeruLoginPage.java
@@ -15,6 +15,11 @@ public class PeruLoginPage extends LoginPage {
     }
 
     @Override
+    public String getLocale() {
+        return "es_PE";
+    }
+
+    @Override
     public void logInAsAdmin() {
         this.logIn("admin", properties.getAdminUserPassword(), MAIN_LOCATION);
     }

--- a/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/SierraLeoneLoginPage.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/SierraLeoneLoginPage.java
@@ -10,6 +10,11 @@ public class SierraLeoneLoginPage extends LoginPage {
     }
 
     @Override
+    public String getLocale() {
+        return "en";
+    }
+
+    @Override
     public void logIn(String user, String password, String location) {
         driver.findElement(By.id("username")).sendKeys(user);
         driver.findElement(By.id("password")).sendKeys(password);


### PR DESCRIPTION
This allows users to be created with different locales. It's a follow-up to https://github.com/PIH/mirebalais-smoke-tests/pull/28#pullrequestreview-808674462 , where I changed the user locales to `{{defaultLocale}}`, which didn't break things as badly as one would expect, for being a completely nonsense locale value. This causes `{{defaultLocale}}` to be interpolated with a locale value provided in the login functions.