### PR TITLE
UHM 7573 - Fix Gladi smoke tests failing intermittmently

### DIFF
--- a/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/DispensingApp.java
+++ b/src/main/java/org/openmrs/module/mirebalais/smoke/pageobjects/DispensingApp.java
@@ -4,6 +4,8 @@ import static org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElemen
 
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.ExpectedCondition;
 
 public class DispensingApp extends AbstractPageObject {
 
@@ -24,14 +26,16 @@ public class DispensingApp extends AbstractPageObject {
         super(driver);
     }
 
-
     public boolean isActivePrescriptionsTabPresent() {
         wait5seconds.until(presenceOfElementLocated(activePrescriptionsSelector));
         return driver.findElement(activePrescriptionsSelector) != null;
     }
 
     public boolean isAllPrescriptionsTabPresent() {
-        wait5seconds.until(presenceOfElementLocated(allPrescriptionsSelector));
+        ExpectedCondition<WebElement> presence = presenceOfElementLocated(allPrescriptionsSelector);
+        System.out.println("Waiting up to 2 minutes for " + presence);
+        wait2minutes.until(presence);
+        System.out.println("Done waiting for " + presence);
         return driver.findElement(allPrescriptionsSelector) != null;
     }
 


### PR DESCRIPTION
We suspect the re-indexing is taking a long time in the gladi server. Increase timeout of the allPrescriptionsSelector selector to see if the test gets fixed.

Testing done:
`mvn clean test -Dtest=MedicationDispensingTest`